### PR TITLE
Fix issue with Metadata not being `Display`ed as valid JSON

### DIFF
--- a/src/lib/dtf/file_format.rs
+++ b/src/lib/dtf/file_format.rs
@@ -71,9 +71,9 @@ impl fmt::Display for Metadata {
   "symbol": "{}",
   "nums": {},
   "max_ts": {},
-  "max_ts_human": {},
+  "max_ts_human": "{}",
   "min_ts": {},
-  "min_ts_human": {}
+  "min_ts_human": "{}"
 }}"#,
             self.symbol,
             self.nums,


### PR DESCRIPTION
Found a very small issue with `dtfcat`'s `-m` option. The metadata is not valid JSON since both {max,min}_ts_human contain invalid values. 

Sample output:

```
{
  "symbol": "bnc_ltc_bnb",
  "nums": 9995,
  "max_ts": 1520252010840,
  "max_ts_human": 2018-03-05 12:13:30 UTC,
  "min_ts": 1520245769613,
  "min_ts_human": 2018-03-05 10:29:29 UTC
}
```

Where valid JSON would be:
```
{
  "symbol": "bnc_ltc_bnb",
  "nums": 9995,
  "max_ts": 1520252010840,
  "max_ts_human": "2018-03-05 12:13:30 UTC",
  "min_ts": 1520245769613,
  "min_ts_human": "2018-03-05 10:29:29 UTC"
}
```





