### PR TITLE
Fix issues with documentation

### DIFF
--- a/src/bin/server/handler.rs
+++ b/src/bin/server/handler.rs
@@ -77,7 +77,7 @@ enum Command<'a> {
 static HELP_STR: &str = "PING, INFO, USE [db], CREATE [db],
 ADD [ts],[seq],[is_trade],[is_bid],[price],[size];
 BULKADD ...; DDAKLUB
-FLUSH, FLUSHALL, GETALL, GET [count], CLEAR
+FLUSH, FLUSH ALL, GET ALL, GET [count], CLEAR
 ";
 
 /// sometimes returns string, sometimes bytes, error string

--- a/src/bin/server/state.rs
+++ b/src/bin/server/state.rs
@@ -43,7 +43,7 @@ pub type SubscriptionTX = futures::sync::mpsc::UnboundedSender<Update>;
 ///
 /// When client adds some updates using ADD or BULKADD,
 /// size increments and updates are added to memory
-/// finally, call FLUSH to commit to disk the current store or FLUSHALL to commit all available stores.
+/// finally, call FLUSH to commit to disk the current store or FLUSH ALL to commit all available stores.
 /// the client can free the updates from memory using CLEAR or CLEARALL
 ///
 #[derive(Debug)]

--- a/src/lib/dtf/file_format.rs
+++ b/src/lib/dtf/file_format.rs
@@ -6,7 +6,7 @@
 //! Offset 00: ([u8; 5]) magic value 0x4454469001
 //! Offset 05: ([u8; 20]) Symbol
 //! Offset 25: (u64) number of records
-//! Offset 33: (u32) max ts
+//! Offset 33: (u64) max ts
 //! Offset 80: -- records - see below --
 //!
 //!


### PR DESCRIPTION
Fixes DTF file specification documentation where `max ts` was wrongly set to `u32` instead of `u64`
Fixes client and documentation displaying invalid "ALL" commands